### PR TITLE
Increase parser lookahead distance

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -33,7 +33,7 @@ func (s *Parser) Parse(parent ast.Node, block text.Reader, pc parser.Context) as
 		offset := 2
 
 	L:
-		for x := 0; x < 5; x++ {
+		for x := 0; x < 20; x++ {
 			for j := offset; j < len(line); j++ {
 				if len(line) > j+1 && line[j] == trigger && line[j+1] == trigger {
 					end = lstart + j


### PR DESCRIPTION
Right now, the parser looks 5 lines ahead for the display mode stuff. However, in my production example, it seemed to break some stuff. I increased it to 20 so others may not suffer from the same headache.

I think in the future something like [goldmark-mathjax](https://github.com/litao91/goldmark-mathjax)'s parser should be used and only the rendering part be done with katex.