### PR TITLE
Expose `throwOnError` from KaTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@ Goldmark Katex is a [Goldmark](https://github.com/yuin/goldmark) extension provi
 ## Usage
 
 ``` go
-goldmark.New(goldmark.WithExtensions(&Extender{})).Convert(src, dst)
+// Default, errors are highlighted in red in the output
+goldmark.New(goldmark.WithExtensions(&katex.Extender{})).Convert(src, dst)
+
+// With ThrowOnError set to true
+goldmark.New(goldmark.WithExtensions(&katex.Extender{
+    ThrowOnError: true,
+})).Convert(src, dst)
 ```
 
 Wrap inline math with a pair of single `$`:

--- a/extender.go
+++ b/extender.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Extender struct {
+	ThrowOnError bool
 }
 
 func (e *Extender) Extend(m goldmark.Markdown) {
@@ -19,6 +20,7 @@ func (e *Extender) Extend(m goldmark.Markdown) {
 		util.Prioritized(&HTMLRenderer{
 			cacheInline:  gcache.New(5000).ARC().Build(),
 			cacheDisplay: gcache.New(5000).ARC().Build(),
+			throwOnError: e.ThrowOnError,
 		}, 0),
 	))
 }

--- a/katex.go
+++ b/katex.go
@@ -12,7 +12,7 @@ import (
 //go:embed katex.min.js
 var code string
 
-func Render(w io.Writer, src []byte, display bool) error {
+func Render(w io.Writer, src []byte, display bool, throwOnError bool) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
@@ -29,8 +29,6 @@ func Render(w io.Writer, src []byte, display bool) error {
 		return err
 	}
 	defer result.Free()
-
-	throwOnError := false
 
 	globals.Set("_EqSrc3120", context.String(string(src)))
 	result, err = context.Eval(fmt.Sprintf(`katex.renderToString(_EqSrc3120, {

--- a/katex.go
+++ b/katex.go
@@ -2,6 +2,7 @@ package katex
 
 import (
 	_ "embed"
+	"fmt"
 	"io"
 	"runtime"
 
@@ -29,12 +30,14 @@ func Render(w io.Writer, src []byte, display bool) error {
 	}
 	defer result.Free()
 
+	throwOnError := false
+
 	globals.Set("_EqSrc3120", context.String(string(src)))
-	if display {
-		result, err = context.Eval("katex.renderToString(_EqSrc3120, { displayMode: true })")
-	} else {
-		result, err = context.Eval("katex.renderToString(_EqSrc3120)")
-	}
+	result, err = context.Eval(fmt.Sprintf(`katex.renderToString(_EqSrc3120, {
+		displayMode: %t,
+		throwOnError: %t
+	})`, display, throwOnError))
+
 	defer result.Free()
 
 	_, err = io.WriteString(w, result.String())

--- a/katex.go
+++ b/katex.go
@@ -35,7 +35,9 @@ func Render(w io.Writer, src []byte, display bool, throwOnError bool) error {
 		displayMode: %t,
 		throwOnError: %t
 	})`, display, throwOnError))
-
+	if err != nil {
+		return err
+	}
 	defer result.Free()
 
 	_, err = io.WriteString(w, result.String())

--- a/katex_test.go
+++ b/katex_test.go
@@ -21,3 +21,21 @@ func BenchmarkRender(b *testing.B) {
 		Render(&b, []byte(`Y = A \dot X^2 + B \dot X + C`), false, false)
 	}
 }
+
+func ErrorRender(t *testing.T) {
+	// with throwOnError = true
+	b := bytes.Buffer{}
+	err := Render(&b, []byte(`\invalidcommand`), false, true)
+	if err == nil {
+		t.Error("Expected error for invalid KaTeX with throwOnError=true, got nil")
+	}
+
+	// with throwOnError = false
+	err = Render(&b, []byte(`\invalidcommand`), false, false)
+	if err != nil {
+		t.Errorf("Expected no error for invalid KaTeX with throwOnError=false, got: %v", err)
+	}
+	if !bytes.Contains(b.Bytes(), []byte("color:#cc0000")) {
+		t.Error("Couldn't find a red error message when rendering invalid KaTeX with throwOnError=false.")
+	}
+}

--- a/katex_test.go
+++ b/katex_test.go
@@ -8,7 +8,7 @@ import (
 
 func ExampleRender() {
 	b := bytes.Buffer{}
-	Render(&b, []byte(`Y = A \dot X^2 + B \dot X + C`), false)
+	Render(&b, []byte(`Y = A \dot X^2 + B \dot X + C`), false, false)
 	fmt.Println(b.String())
 
 	// Output:
@@ -18,6 +18,6 @@ func ExampleRender() {
 func BenchmarkRender(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		b := bytes.Buffer{}
-		Render(&b, []byte(`Y = A \dot X^2 + B \dot X + C`), false)
+		Render(&b, []byte(`Y = A \dot X^2 + B \dot X + C`), false, false)
 	}
 }

--- a/katex_test.go
+++ b/katex_test.go
@@ -22,7 +22,7 @@ func BenchmarkRender(b *testing.B) {
 	}
 }
 
-func ErrorRender(t *testing.T) {
+func TestRenderError(t *testing.T) {
 	// with throwOnError = true
 	b := bytes.Buffer{}
 	err := Render(&b, []byte(`\invalidcommand`), false, true)

--- a/renderer.go
+++ b/renderer.go
@@ -35,7 +35,7 @@ func (r *HTMLRenderer) renderInline(w util.BufWriter, source []byte, n ast.Node,
 
 		if err == gcache.KeyNotFoundError {
 			b := bytes.Buffer{}
-			err = Render(&b, node.Equation, false)
+			err = Render(&b, node.Equation, false, false)
 			if err != nil {
 				return ast.WalkStop, err
 			}
@@ -64,7 +64,7 @@ func (r *HTMLRenderer) renderBlock(w util.BufWriter, source []byte, n ast.Node, 
 
 		if err == gcache.KeyNotFoundError {
 			b := bytes.Buffer{}
-			err = Render(&b, node.Equation, true)
+			err = Render(&b, node.Equation, true, false)
 			if err != nil {
 				return ast.WalkStop, err
 			}

--- a/renderer.go
+++ b/renderer.go
@@ -15,6 +15,7 @@ type HTMLRenderer struct {
 
 	cacheInline  gcache.Cache
 	cacheDisplay gcache.Cache
+	throwOnError bool
 }
 
 func (r *HTMLRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
@@ -35,7 +36,7 @@ func (r *HTMLRenderer) renderInline(w util.BufWriter, source []byte, n ast.Node,
 
 		if err == gcache.KeyNotFoundError {
 			b := bytes.Buffer{}
-			err = Render(&b, node.Equation, false, false)
+			err = Render(&b, node.Equation, false, r.throwOnError)
 			if err != nil {
 				return ast.WalkStop, err
 			}
@@ -64,7 +65,7 @@ func (r *HTMLRenderer) renderBlock(w util.BufWriter, source []byte, n ast.Node, 
 
 		if err == gcache.KeyNotFoundError {
 			b := bytes.Buffer{}
-			err = Render(&b, node.Equation, true, false)
+			err = Render(&b, node.Equation, true, r.throwOnError)
 			if err != nil {
 				return ast.WalkStop, err
 			}


### PR DESCRIPTION
``` go
// Default, errors are highlighted in red in the output
goldmark.New(goldmark.WithExtensions(&katex.Extender{})).Convert(src, dst)

// With ThrowOnError set to true, errors are accessible in Go
goldmark.New(goldmark.WithExtensions(&katex.Extender{
    ThrowOnError: true,
})).Convert(src, dst)
```